### PR TITLE
Implemented reset password tokens

### DIFF
--- a/API_v1.md
+++ b/API_v1.md
@@ -2,6 +2,10 @@
 
 ### POST /v1/user/create
 
+Creates a new user.
+
+Event: user.created (user_id, profile_name, email)
+
 + Request 
 
 	login_name=mr.example@acme.com&login_password=TopSecret&profile_name=Mr.%20Example&email=mr.example@acme.com
@@ -34,6 +38,8 @@
 Flags the email of the user as verified. The `email` parameter is optional and can be used to ensure that the correct email
 gets verified - maybe the user changed the email after the original verification email was sent out.
 
+Event: user.email_verified (user_id, email)
+
 + Response 204
 + Response 400
 + Response 404
@@ -42,15 +48,25 @@ gets verified - maybe the user changed the email after the original verification
 
 Updates the email of the user identified by `userid`.
 
+Event: user.change_email (user_id, email)
+
 ### POST /v1/user/change_profile_name?id={userid}&profile_name={name}
+
+Changes the profile name of the user.
+
+Event: user.change_profile_name (user_id, profile_name)
 
 ### POST /v1/user/change_login_credentials?id={userid}&name={name}&password={password}
 
 Updates the credentials to be used with `/authenticate`.
 
+Event: user.change_login_credentials (user_id)
+
 ### POST /v1/user/authenticate?name={login_name}&password={login_password}
 
 Performs an authentication with given credentials. If the credentials are valid and the user can be authenticated (e.g. is not locked), the userid will be returned.
+
+Event: user.authenticated (user_id)
 
 + Response 204
 
@@ -58,6 +74,34 @@ Performs an authentication with given credentials. If the credentials are valid 
 
 + Response 400
 + Response 404
+
+### POST /v1/user/new_reset_login_credentials_token?email={email}&login_name={login_name}
+
+Creates a new reset password token, associates it with the user and returns it. The consumer should forward this token to the user's email (or via another communication medium which is known to reach the real user) to verify that the initiator is the real user.
+
+One of the arguments must be given, the second if optional. If both are given, a user must match both values.
+
+Event: user.new_reset_login_credentials_token(user_id, token)
+
++ Response 200
+
+		{
+			"token": "{token}"
+		}
+
++ Response 404
+
+		Unknown user id.
+
+### POST /v1/user/reset_login_credentials?token={token}&login_name={login_name}&login_password={login_password}
+
+Resets the user's credentials.
+
++ Response 204
++ Response 400
+
+		Invalid token.
+
 
 ### GET /v1/feed
 

--- a/API_v1.md
+++ b/API_v1.md
@@ -75,13 +75,11 @@ Event: user.authenticated (user_id)
 + Response 400
 + Response 404
 
-### POST /v1/user/new_reset_login_credentials_token?email={email}&login_name={login_name}
+### POST /v1/user/new_reset_login_credentials_token?email={email}
 
 Creates a new reset password token, associates it with the user and returns it. The consumer should forward this token to the user's email (or via another communication medium which is known to reach the real user) to verify that the initiator is the real user.
 
-One of the arguments must be given, the second if optional. If both are given, a user must match both values.
-
-Event: user.new_reset_login_credentials_token(user_id, token)
+Event: user.new_reset_login_credentials_token(user_id, email, token)
 
 + Response 200
 

--- a/client/api.go
+++ b/client/api.go
@@ -239,8 +239,8 @@ func (call ChangeLoginCredentialsCall) ResponseNoContent(resp *http.Response) (i
 
 // ------------------------
 
-func ApiNewResetPasswordToken(email, login_name string) (string, error) {
-	token, err := Execute(Endpoint("new_reset_login_credentials_token"), NewResetPasswordToken{email, login_name})
+func ApiNewResetPasswordToken(email string) (string, error) {
+	token, err := Execute(Endpoint("new_reset_login_credentials_token"), NewResetPasswordToken{email})
 	if err != nil {
 		return "", errgo.Mask(err)
 	}
@@ -248,13 +248,11 @@ func ApiNewResetPasswordToken(email, login_name string) (string, error) {
 }
 
 type NewResetPasswordToken struct {
-	Email     string
-	LoginName string
+	Email string
 }
 
 func (call NewResetPasswordToken) PostForm() url.Values {
 	p := url.Values{}
-	p.Set("login_name", call.LoginName)
 	p.Set("email", call.Email)
 	return p
 }

--- a/client/api.go
+++ b/client/api.go
@@ -238,3 +238,59 @@ func (call ChangeLoginCredentialsCall) ResponseNoContent(resp *http.Response) (i
 }
 
 // ------------------------
+
+func ApiNewResetPasswordToken(email, login_name string) (string, error) {
+	token, err := Execute(Endpoint("new_reset_login_credentials_token"), NewResetPasswordToken{email, login_name})
+	if err != nil {
+		return "", errgo.Mask(err)
+	}
+	return token.(string), nil
+}
+
+type NewResetPasswordToken struct {
+	Email     string
+	LoginName string
+}
+
+func (call NewResetPasswordToken) PostForm() url.Values {
+	p := url.Values{}
+	p.Set("login_name", call.LoginName)
+	p.Set("email", call.Email)
+	return p
+}
+
+func (call NewResetPasswordToken) ResponseOK(resp *http.Response) (interface{}, error) {
+	target := map[string]interface{}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&target); err != nil {
+		return "", errgo.Mask(err)
+	}
+	return target["token"], nil
+}
+
+// ------------------------
+
+func ApiResetLoginCredentials(token, login_name, login_password string) error {
+	_, err := Execute(Endpoint("reset_login_credentials"), ResetLoginCredentials{token, login_name, login_password})
+	return errgo.Mask(err)
+}
+
+type ResetLoginCredentials struct {
+	Token         string
+	LoginName     string
+	LoginPassword string
+}
+
+func (call ResetLoginCredentials) PostForm() url.Values {
+	p := url.Values{}
+	p.Set("login_name", call.LoginName)
+	p.Set("token", call.Token)
+	p.Set("login_password", call.LoginPassword)
+	return p
+}
+
+func (call ResetLoginCredentials) ResponseNoContent(resp *http.Response) (interface{}, error) {
+	return nil, nil
+}
+
+// ------------------------

--- a/client/helper.go
+++ b/client/helper.go
@@ -124,12 +124,7 @@ func Execute(url string, call Call) (interface{}, error) {
 
 	}
 
-	data := make([]byte, 2048)
-
-	if _, err := io.ReadFull(response.Body, data); err != nil {
-		panic(err)
-	}
-	return nil, fmt.Errorf("No handler found for status code %d for URL %s %s: %s", response.StatusCode, method, url, string(data))
+	return nil, fmt.Errorf("No handler found for status code %d for URL %s %s", response.StatusCode, method, url)
 }
 
 // ------------------

--- a/client/reset_login_credentials_test.go
+++ b/client/reset_login_credentials_test.go
@@ -4,54 +4,12 @@ import (
 	"testing"
 )
 
-func TestIntegrationUserLoginCredentialsForgotten_OnlyEmail__SuiteAll(t *testing.T) {
+func TestIntegrationUserLoginCredentialsForgotten__SuiteAll(t *testing.T) {
 	user := Builder.givenNewVerifiedUser(t)
 
 	newLoginName := Builder.Fake.UserName()
 
-	token, err := ApiNewResetPasswordToken(user.Email, "")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	if err := ApiResetLoginCredentials(token, newLoginName, Password); err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	if userID, err := ApiAuthenticate(newLoginName, Password); err != nil {
-		t.Fatalf("error %v", err)
-	} else if userID != user.userID {
-		t.Fatalf("Authenticated as wrong user. expected '%s' != actual '%s'", user.userID, userID)
-	}
-}
-
-func TestIntegrationUserLoginCredentialsForgotten_OnlyName__SuiteAll(t *testing.T) {
-	user := Builder.givenNewVerifiedUser(t)
-
-	newLoginName := Builder.Fake.UserName()
-
-	token, err := ApiNewResetPasswordToken("", user.LoginName)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	if err := ApiResetLoginCredentials(token, newLoginName, Password); err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	if userID, err := ApiAuthenticate(newLoginName, Password); err != nil {
-		t.Fatalf("error %v", err)
-	} else if userID != user.userID {
-		t.Fatalf("Authenticated as wrong user. expected '%s' != actual '%s'", user.userID, userID)
-	}
-}
-
-func TestIntegrationUserLoginCredentialsForgotten_Both__SuiteAll(t *testing.T) {
-	user := Builder.givenNewVerifiedUser(t)
-
-	newLoginName := Builder.Fake.UserName()
-
-	token, err := ApiNewResetPasswordToken(user.Email, user.LoginName)
+	token, err := ApiNewResetPasswordToken(user.Email)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/client/reset_login_credentials_test.go
+++ b/client/reset_login_credentials_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestIntegrationUserLoginCredentialsForgotten_OnlyEmail__SuiteAll(t *testing.T) {
+	user := Builder.givenNewVerifiedUser(t)
+
+	newLoginName := Builder.Fake.UserName()
+
+	token, err := ApiNewResetPasswordToken(user.Email, "")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if err := ApiResetLoginCredentials(token, newLoginName, Password); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if userID, err := ApiAuthenticate(newLoginName, Password); err != nil {
+		t.Fatalf("error %v", err)
+	} else if userID != user.userID {
+		t.Fatalf("Authenticated as wrong user. expected '%s' != actual '%s'", user.userID, userID)
+	}
+}
+
+func TestIntegrationUserLoginCredentialsForgotten_OnlyName__SuiteAll(t *testing.T) {
+	user := Builder.givenNewVerifiedUser(t)
+
+	newLoginName := Builder.Fake.UserName()
+
+	token, err := ApiNewResetPasswordToken("", user.LoginName)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if err := ApiResetLoginCredentials(token, newLoginName, Password); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if userID, err := ApiAuthenticate(newLoginName, Password); err != nil {
+		t.Fatalf("error %v", err)
+	} else if userID != user.userID {
+		t.Fatalf("Authenticated as wrong user. expected '%s' != actual '%s'", user.userID, userID)
+	}
+}
+
+func TestIntegrationUserLoginCredentialsForgotten_Both__SuiteAll(t *testing.T) {
+	user := Builder.givenNewVerifiedUser(t)
+
+	newLoginName := Builder.Fake.UserName()
+
+	token, err := ApiNewResetPasswordToken(user.Email, user.LoginName)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if err := ApiResetLoginCredentials(token, newLoginName, Password); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if userID, err := ApiAuthenticate(newLoginName, Password); err != nil {
+		t.Fatalf("error %v", err)
+	} else if userID != user.userID {
+		t.Fatalf("Authenticated as wrong user. expected '%s' != actual '%s'", user.userID, userID)
+	}
+}

--- a/middlewares/v1/web.go
+++ b/middlewares/v1/web.go
@@ -270,9 +270,8 @@ type NewResetLoginCredentialsHandler struct{ BaseHandler }
 
 func (r *NewResetLoginCredentialsHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	email := req.FormValue("email")
-	login_name := req.FormValue("login_name")
 
-	token, err := r.UserService.NewResetLoginCredentialsToken(email, login_name)
+	token, err := r.UserService.NewResetLoginCredentialsToken(email)
 	if err != nil {
 		r.handleProcessingError(resp, req, err)
 	} else {

--- a/middlewares/v1/web.go
+++ b/middlewares/v1/web.go
@@ -33,6 +33,9 @@ func NewUserAPIHandler(userService *service.UserService) http.Handler {
 
 	mux.Methods("POST").Path("/v1/user/authenticate").Handler(&AuthenticationHandler{base})
 
+	mux.Methods("POST").Path("/v1/user/new_reset_login_credentials_token").Handler(&NewResetLoginCredentialsHandler{base})
+	mux.Methods("POST").Path("/v1/user/reset_login_credentials").Handler(&ResetCredentialsTokenHandler{base})
+
 	mux.Methods("GET").Path("/v1/feed").Handler(&FeedWriter{base})
 
 	return mux
@@ -260,6 +263,39 @@ func (h *VerifyEmailHandler) Email(req *http.Request) (string, bool) {
 		return "", false
 	}
 	return email[0], true
+}
+
+// ----------------------------------------------
+type NewResetLoginCredentialsHandler struct{ BaseHandler }
+
+func (r *NewResetLoginCredentialsHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	email := req.FormValue("email")
+	login_name := req.FormValue("login_name")
+
+	token, err := r.UserService.NewResetLoginCredentialsToken(email, login_name)
+	if err != nil {
+		r.handleProcessingError(resp, req, err)
+	} else {
+		httputil.WriteJSONResponse(resp, http.StatusOK, map[string]interface{}{
+			"token": token,
+		})
+	}
+}
+
+// ----------------------------------------------
+type ResetCredentialsTokenHandler struct{ BaseHandler }
+
+func (r *ResetCredentialsTokenHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	token := req.FormValue("token")
+	login_name := req.FormValue("login_name")
+	login_password := req.FormValue("login_password")
+
+	token, err := r.UserService.ResetCredentialsWithToken(token, login_name, login_password)
+	if err != nil {
+		r.handleProcessingError(resp, req, err)
+	} else {
+		httputil.WriteNoContent(resp)
+	}
 }
 
 // ----------------------------------------------

--- a/service/backend_wrapper.go
+++ b/service/backend_wrapper.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"./user"
+
+	"log"
+)
+
+const logUserStorageCalls = false
+
+type UserStorageWrapper struct {
+	UserStorage UserStorage
+}
+
+func (w *UserStorageWrapper) Save(user user.User) error {
+	err := w.UserStorage.Save(user)
+	if logUserStorageCalls {
+		log.Printf("UserStorage.Save(%#v) =>\n\t%#v", user, err)
+	}
+	return err
+}
+func (w *UserStorageWrapper) Get(userId string) (user.User, error) {
+	user, err := w.UserStorage.Get(userId)
+	if logUserStorageCalls {
+		log.Printf("UserStorage.Get(%#v) =>\n\t(%#v, %#v)", userId, user, err)
+	}
+	return user, err
+}
+func (w *UserStorageWrapper) FindByLoginName(loginName string) (user.User, error) {
+	user, err := w.UserStorage.FindByLoginName(loginName)
+	if logUserStorageCalls {
+		log.Printf("UserStorage.FindByLoginName(%#v) =>\n\t(%#v, %#v)", loginName, user, err)
+	}
+	return user, err
+}
+func (w *UserStorageWrapper) FindByEmail(email string) (user.User, error) {
+	user, err := w.UserStorage.FindByEmail(email)
+	if logUserStorageCalls {
+		log.Printf("UserStorage.FindByEmail(%#v) =>\n\t(%#v, %#v)", email, user, err)
+	}
+	return user, err
+}
+func (w *UserStorageWrapper) FindByResetPasswordToken(token string) (user.User, error) {
+	user, err := w.UserStorage.FindByResetPasswordToken(token)
+	if logUserStorageCalls {
+		log.Printf("UserStorage.FindByResetPasswordToken(%#v) =>\n\t(%#v, %#v)", token, user, err)
+	}
+	return user, err
+}

--- a/service/backends.go
+++ b/service/backends.go
@@ -6,6 +6,10 @@ import (
 
 type IdFactory interface {
 	NewUserID() string
+
+	// Generates a new password token to be used for the password reset feature.
+	// The result must never be empty.
+	NewResetPasswordToken() string
 }
 
 // This follows the design of the PHP password_* functions. The client don't need to know anything about the user algorithms.
@@ -20,6 +24,8 @@ type UserStorage interface {
 	Get(userId string) (user.User, error)
 
 	FindByLoginName(loginName string) (user.User, error)
+	FindByEmail(email string) (user.User, error)
+	FindByResetPasswordToken(token string) (user.User, error)
 }
 
 // EventLog abstracts any eventlog for store the business events of the UserService.

--- a/service/errors.go
+++ b/service/errors.go
@@ -11,10 +11,12 @@ var (
 )
 
 var (
-	InvalidArguments         = errgo.New("Invalid arguments.")
-	InvalidCredentials       = errgo.New("Invalid credentials.")
-	InvalidVerificationEmail = errgo.New("Email adress does not match current email for user.")
-	UserEmailMustBeVerified  = errgo.New("Email must be verified to authenticate.")
+	InvalidConfig             = errgo.New("Invalid config")
+	InvalidArguments          = errgo.New("Invalid arguments.")
+	InvalidCredentials        = errgo.New("Invalid credentials.")
+	InvalidVerificationEmail  = errgo.New("Email adress does not match current email for user.")
+	ResetPasswordTokenExpired = errgo.New("The ResetPasswordToken has expired.")
+	UserEmailMustBeVerified   = errgo.New("Email must be verified to authenticate.")
 )
 
 func IsNotFoundError(err error) bool {
@@ -34,5 +36,10 @@ func IsUserEmailMustBeVerifiedError(err error) bool {
 }
 
 func IsServiceError(err error) bool {
-	return err == InvalidArguments || err == InvalidCredentials || err == InvalidVerificationEmail
+	err = errgo.Cause(err)
+	return err == ResetPasswordTokenExpired || err == InvalidArguments || err == InvalidCredentials || err == InvalidVerificationEmail || err == InvalidConfig
+}
+
+func newInvalidConfig(field string, value interface{}) error {
+	return errgo.Notef(InvalidConfig, "Invalid config value for field %s: %v", field, value)
 }

--- a/service/idfactory/sequence.go
+++ b/service/idfactory/sequence.go
@@ -21,3 +21,6 @@ func (seq *sequenceFactory) NewUserID() string {
 		return fmt.Sprintf(seq.Format, seq.Sequence)
 	}
 }
+func (seq *sequenceFactory) NewResetPasswordToken() string {
+	return seq.NewUserID()
+}

--- a/service/idfactory/uuid.go
+++ b/service/idfactory/uuid.go
@@ -9,3 +9,7 @@ type UUIDFactory struct{}
 func (factory *UUIDFactory) NewUserID() string {
 	return uuid.New()
 }
+
+func (factory *UUIDFactory) NewResetPasswordToken() string {
+	return uuid.New()
+}

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,7 @@ import (
 
 	"encoding/json"
 	"log"
+	"time"
 )
 
 type Dependencies struct {
@@ -19,9 +20,32 @@ type Dependencies struct {
 type Config struct {
 	AuthEmailMustBeVerified bool
 	MaxItems                int
+
+	// How long can a ResetPasswordToken be used?
+	ResetPasswordExpireTime time.Duration
+}
+
+func (c Config) ValidateValues() error {
+	if c.MaxItems <= 0 {
+		return newInvalidConfig("MaxItems", c.MaxItems)
+	}
+	if c.ResetPasswordExpireTime <= 0 {
+		return newInvalidConfig("ResetPasswordExpireTime", c.ResetPasswordExpireTime)
+	}
+	return nil
+}
+
+// Validate checks all values and panics if any one is invalid.
+func (c Config) Validate() {
+	if err := c.ValidateValues(); err != nil {
+		panic(err)
+	}
 }
 
 func NewUserService(config Config, deps Dependencies) *UserService {
+	config.Validate()
+
+	deps.UserStorage = &UserStorageWrapper{deps.UserStorage}
 	return &UserService{
 		Dependencies: deps,
 		Config:       config,
@@ -67,6 +91,7 @@ func (us *UserService) CreateUser(profileName, email, loginName, loginPassword s
 	us.logEvent("user.created", map[string]interface{}{
 		"user_id":      newUserID,
 		"profile_name": profileName,
+		"email":        email,
 	})
 
 	return newUserID, nil
@@ -206,6 +231,110 @@ func (us *UserService) CheckAndSetEmailVerified(userID, email string) error {
 			"email":   user.Email,
 		})
 	})
+}
+
+// NewResetLoginCredentialsToken creates a new reset password token, associates it with the user and returns it. The
+// consumer should forward this token to the user's email (or via another communication medium which is known
+// to reach the real user) to verify that the initiator is the real user.
+//
+// One of the arguments must be given, the second if optional. If both are given, a user must match both values.
+//
+// Event: user.new_reset_password_token(user_id, reset_login_credentials_token)
+//
+// Returs the new token to reset the password with or an error if no user could be found.
+func (us *UserService) NewResetLoginCredentialsToken(email, login_name string) (string, error) {
+	if email == "" && login_name == "" {
+		// Only one may be empty
+		return "", InvalidArguments
+	}
+	log.Printf("call NewResetLoginCredentialsToken('%s', '%s')", email, login_name)
+
+	var user user.User
+	var err error
+
+	if user.ID == "" && login_name != "" {
+		log.Println("FindByLoginName")
+		user, err = us.UserStorage.FindByLoginName(login_name)
+		if err != nil {
+			if !IsNotFoundError(err) {
+				return "", Mask(err)
+			}
+		}
+	}
+
+	if user.ID == "" && email != "" {
+		log.Println("FindByEmail", email)
+		user, err = us.UserStorage.FindByEmail(email)
+		if err != nil {
+			if !IsNotFoundError(err) {
+				return "", Mask(err)
+			}
+		}
+	}
+
+	log.Printf("user %#v\nerr %#v\n", user, err)
+
+	// Last, check if we have a user
+	if IsNotFoundError(err) {
+		return "", Mask(err)
+	}
+	if user.ID == "" {
+		log.Printf("user %v\n", user)
+		log.Printf("err: %v\n", err)
+		panic("Invalid state reached for " + email + "," + login_name + ".")
+	}
+
+	resetPasswordToken := us.IdFactory.NewResetPasswordToken()
+	resetPasswordIssued := time.Now()
+
+	user.ResetPasswordToken = resetPasswordToken
+	user.ResetPasswordTokenIssued = &resetPasswordIssued
+
+	if err := us.UserStorage.Save(user); err != nil {
+		return "", Mask(err)
+	}
+
+	us.logEvent("user.new_reset_login_credentials_token", map[string]interface{}{
+		"user_id": user.ID,
+		"token":   resetPasswordToken,
+	})
+	return resetPasswordToken, nil
+}
+
+// ResetCredentialsWithToken checks for users with the given token and resets their login credentials to given values.
+//
+// Event: user.
+func (us *UserService) ResetCredentialsWithToken(resetPasswordToken, new_login_name, new_login_password string) (string, error) {
+	if resetPasswordToken == "" || new_login_name == "" || new_login_password == "" {
+		return "", Mask(InvalidArguments)
+	}
+
+	user, err := us.UserStorage.FindByResetPasswordToken(resetPasswordToken)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return "", Mask(InvalidArguments)
+		}
+		return "", Mask(err)
+	}
+
+	if time.Now().After(user.ResetPasswordTokenIssued.Add(us.ResetPasswordExpireTime)) {
+		return "", Mask(ResetPasswordTokenExpired)
+	}
+
+	user.LoginName = new_login_name
+	user.LoginPasswordHash = us.Hasher.Hash(new_login_password)
+	user.ResetPasswordToken = ""
+	user.ResetPasswordTokenIssued = nil
+
+	if err := us.UserStorage.Save(user); err != nil {
+		return "", Mask(err)
+	}
+
+	us.logEvent("user.login_credentials_resetted", map[string]interface{}{
+		"user_id": user.ID,
+	})
+
+	return user.ID, nil
 }
 
 // readModifyWrite reads the user with the given userID, applies modifier to it, saves the result

--- a/service/storage/keyvalue_etcd.go
+++ b/service/storage/keyvalue_etcd.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/errgo"
 )
 
+const userDataName = "user"
+
 // KeyFormat (ETCD):
 //  /moinz.de/userd/user/<userid> = JSON()
 //  /moinz.de/userd/email/<email> = userid()
@@ -60,7 +62,7 @@ func (d *EtcdStorageDriver) Index(name string) keyValueIndex {
 
 // Set writes the json with data
 func (d *EtcdStorageDriver) Set(userID, json string) error {
-	key := d.Path("user", userID)
+	key := d.Path(userDataName, userID)
 	_, err := d.client.Set(key, json, d.ttl)
 	return errgo.Mask(err)
 }
@@ -72,7 +74,7 @@ func (d *EtcdStorageDriver) create(key, value string) error {
 
 // Lookup returns the json previously written with Set().
 func (d *EtcdStorageDriver) Lookup(userID string) (string, bool, error) {
-	json, ok, err := d.lookupIndex("user", userID)
+	json, ok, err := d.lookupIndex(userDataName, userID)
 	if err != nil {
 		return "", false, errgo.Mask(err)
 	}

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -1,5 +1,9 @@
 package user
 
+import (
+	"time"
+)
+
 type User struct {
 	ID string
 
@@ -10,4 +14,7 @@ type User struct {
 
 	Email         string
 	EmailVerified bool
+
+	ResetPasswordToken       string
+	ResetPasswordTokenIssued *time.Time
 }


### PR DESCRIPTION
Fixes #5 
- Adds two new routes to create a reset_login_credentials token and use it to reset the login credentials
- Added eventstream events to API documentation
- Verify UserService config
- Use `log.Fatalf` instead of `panic()` for invalid command line arguments
